### PR TITLE
Prevent mistakenly opening a search box in some situations

### DIFF
--- a/src/core/content.js
+++ b/src/core/content.js
@@ -75,7 +75,7 @@ function isEditable (element) {
     document.designMode === "on" ||
     element.isContentEditable ||
     (
-      (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT')
+      (element.localName === "input" || element.localName === "textarea" || element.localName === "select")
       && (!element.type || editableInputTypes.includes(element.type))
       && !element.disabled
       && !element.readOnly

--- a/src/core/content.js
+++ b/src/core/content.js
@@ -72,6 +72,7 @@ function isEditable (element) {
   const editableInputTypes = ["text", "textarea", "password", "email", "number", "tel", "url", "search"];
 
   return (
+    document.designMode === "on" ||
     element.isContentEditable ||
     (
       (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT')

--- a/src/core/content.js
+++ b/src/core/content.js
@@ -1,19 +1,5 @@
 "use strict";
 
-const excludedTriggerKeys = [
-  'Shift',
-  'Alt',
-  'Control',
-  'Meta',
-  'ContextMenu',
-  'OS',
-  'AltGraph',
-  'Escape',
-  ' ',
-  'Dead',
-  'Enter'
-];
-
 
 let triggerKey = "";
 
@@ -56,7 +42,7 @@ function handleKeydown (event) {
     }
 
     // check if is character key
-    else if (event.code !== event.key && !excludedTriggerKeys.includes(event.key)) {
+    else if (!/\w\w/.test(event.key) && event.key !== " ") {
       pressedKey = event.key;
     }
 


### PR DESCRIPTION
Below some test cases to demonstrate the wrong behavior that each commit fixes.

#### Improve identifying keys as character keys

Press 2 on the numeric keypad while NumLock is off (it is used as an arrow key).

#### Deactivate on pages with design mode enabled

<https://www-archive.mozilla.org/editor/midasdemo/>.

#### Fix input field detection in XHTML documents

Try to enter a search query at <https://golem.ph.utexas.edu/cgi-bin/MT-3.0/mt-search.cgi>.
